### PR TITLE
Improved thread_list_macros

### DIFF
--- a/_data/template_modifications.xml
+++ b/_data/template_modifications.xml
@@ -197,8 +197,8 @@ $0]]></replace>
     <find><![CDATA[{$forum.thread_prompt}]]></find>
     <replace><![CDATA[{{ ($forum->QT_type === 'questions_only' && $xf.options.QT_useQuestionPrompt) ? phrase('QT_question_title') : $forum.thread_prompt }}]]></replace>
   </modification>
-  <modification type="public" template="thread_list_macros" modification_key="QT_thread_list_macros_question_additions" description="Adding question mark and best answer icons before thread title" execution_order="10" enabled="1" action="str_replace">
-    <find><![CDATA[<div class="structItem-title">]]></find>
+  <modification type="public" template="thread_list_macros" modification_key="QT_thread_list_macros_question_additions" description="Adding question mark and best answer icons before thread title" execution_order="10" enabled="1" action="preg_replace">
+    <find><![CDATA[/<div class=\"structItem\-title\".*>/]]></find>
     <replace><![CDATA[$0
 
 <xf:include template="QT_thread_list_macros_question_additions" />]]></replace>

--- a/_output/template_modifications/public/QT_thread_list_macros_question_additions.json
+++ b/_output/template_modifications/public/QT_thread_list_macros_question_additions.json
@@ -3,7 +3,7 @@
     "description": "Adding question mark and best answer icons before thread title",
     "execution_order": 10,
     "enabled": true,
-    "action": "str_replace",
-    "find": "<div class=\"structItem-title\">",
+    "action": "preg_replace",
+    "find": "<div class=\"structItem-title\".*>",
     "replace": "$0\n\n<xf:include template=\"QT_thread_list_macros_question_additions\" />"
 }

--- a/hashes.json
+++ b/hashes.json
@@ -43,7 +43,7 @@
     "src/addons/QuestionThreads/_data/style_properties.xml": "f02d72c219fdb18dd4da60702dc4592f30d262ce05d250842a49334004e37628",
     "src/addons/QuestionThreads/_data/style_property_groups.xml": "d231b6076671d500b07d515589e69616e46332095727046b512579eca49ec813",
     "src/addons/QuestionThreads/_data/templates.xml": "9e25114a7e1492f59c926f120cff68bd6b6339ba8a391600de01eb15ec5606b7",
-    "src/addons/QuestionThreads/_data/template_modifications.xml": "decfc2e41217795b9ba654dc62278526d8cad096a74496c223420fd2b8f052cd",
+    "src/addons/QuestionThreads/_data/template_modifications.xml": "AB2B64B7FB719C2DC92BD3D596072BA550230AAD6E099A1781165987F8135688",
     "src/addons/QuestionThreads/_data/widget_definitions.xml": "37e46965256430f24004c2e7f08ba08f9b0d1cbcc4d70e84b3f4e3ffb713e64b",
     "src/addons/QuestionThreads/_data/widget_positions.xml": "a29cee66134f6bc5d75ed9df1eef21096c24401915c5b5c774389c3d7bb2d5b3"
 }


### PR DESCRIPTION
This adds support for universal `<div class="structItem-title">` tags like `<div class="structItem-title" uix-data-href="/community/threads/zoom-and-pan-question.11155/">` (used in TH themes).